### PR TITLE
Removed package name from header

### DIFF
--- a/cui/classes/model.py
+++ b/cui/classes/model.py
@@ -257,7 +257,7 @@ class ApplicationModel(BaseApplication):
                 else:
                     post.append(src[:-8])
         header = (
-            _("Use the arrow keys to switch between logfiles. <urwid.LEFT> and <RIGHT> "
+            _("Use the arrow keys to switch between logfiles. <LEFT> and <RIGHT> "
               "switch the logfile, while <+> and <-> changes the line count to view. "
               "(%s)") % self.control.log_control.log_line_count
         )


### PR DESCRIPTION
Fixing the header showing <urwid.LEFT> instead of <LEFT>

![image](https://github.com/grommunio/grommunio-cui/assets/4681318/0e39e895-bc4c-4c31-8a49-4a91032002b6)
